### PR TITLE
chore: Adds companion files for `asdf` and `direnv`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+#Toolings#
+############
+#direnv
+.envrc
+.env
+
 # CDK, and CDK asset staging directory
 .cdk.staging
 cdk.out

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+direnv 2.32.1
+nodejs 18.12.0
+yarn 1.22.19

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "golang.go",
+    "redhat.vscode-yaml"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "editor.formatOnSave": true,
+  "eslint.workingDirectories": ["backend"]
+}

--- a/backend/.envrc_example
+++ b/backend/.envrc_example
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+#CDK Stack Specifics
+export AWS_ACCOUNT_ID=""
+#FYI: Region retrieve from AWS CLI session


### PR DESCRIPTION
# Purpose :dart:

These changes introduce companion files for `asdf` tool version manager, and `direnv`, as well as `vscode` extensions and settings for said extensions. These changes aim to reduce the barrier of entry in identifying what is needed in their workspace to be productive in the project.

# Context :brain:

Part of an effort to initialize this project.

# Notes :notebook:

- `asdf`: https://asdf-vm.com/
- `direnv: https://direnv.net/
