### PR TITLE
Removes PoC infra components and API code, and increases API throttling limits

### DIFF
--- a/backend/ops/src/stacks/backend-stack.ts
+++ b/backend/ops/src/stacks/backend-stack.ts
@@ -108,11 +108,7 @@ export class BackendStack extends cdk.Stack {
 
     //b.s. example of API paths
     const v1 = api.root.addResource("v1")
-    const formation = v1.addResource("formationId")
     const playerHand = v1.addResource("playerHand")
-    const formationPostMethod = formation.addMethod("POST", apiIntegration, {
-      apiKeyRequired: false,
-    }) //Set apiKeyRequired to `true` when ready to start locking down the API
 
     //Need to create individual validator objects, refer to: https://github.com/aws/aws-cdk/issues/7613
     const playerHandPostValidator = new apigateway.RequestValidator(
@@ -169,8 +165,8 @@ export class BackendStack extends cdk.Stack {
 
     const plan = api.addUsagePlan("legalBrawlUsagePlan", {
       throttle: {
-        rateLimit: 10,
-        burstLimit: 2,
+        rateLimit: 50,
+        burstLimit: 10,
       },
     })
 
@@ -178,31 +174,24 @@ export class BackendStack extends cdk.Stack {
       stage: api.deploymentStage,
       throttle: [
         {
-          method: formationPostMethod,
-          throttle: {
-            rateLimit: 10,
-            burstLimit: 2,
-          },
-        },
-        {
           method: playerHandPost,
           throttle: {
-            rateLimit: 10,
-            burstLimit: 2,
+            rateLimit: 50,
+            burstLimit: 10,
           },
         },
         {
           method: playerHandGet,
           throttle: {
-            rateLimit: 10,
-            burstLimit: 2,
+            rateLimit: 50,
+            burstLimit: 10,
           },
         },
         {
           method: playerHandPut,
           throttle: {
-            rateLimit: 10,
-            burstLimit: 2,
+            rateLimit: 50,
+            burstLimit: 10,
           },
         },
       ],

--- a/backend/src/aws/apigateway.go
+++ b/backend/src/aws/apigateway.go
@@ -104,12 +104,6 @@ func HandleRequest(ctx context.Context, request events.APIGatewayProxyRequest) (
 
 	switch request.Path {
 
-	case "/v1/formationId":
-		response = events.APIGatewayProxyResponse{
-			Body:       "Hello, World!",
-			StatusCode: 200,
-		}
-
 	case "/v1/playerHand":
 		switch request.HTTPMethod {
 


### PR DESCRIPTION
# Purpose :dart:
These changes clean up PoC backend infra, and API logic code as they no longer serve a purpose.

Additionally, the API throttling limits have been increased so that it can support demonstrations with friends and family.

# Context :brain:

We are approaching the pointy-tend of the `game-jam-2022`!

# Notes :notebook:
- These changes should only be merged once the API code has been merged (PR link pending)