### PR TITLE
feat: Adds components for CORS support

### DIFF
--- a/backend/ops/src/stacks/backend-stack.ts
+++ b/backend/ops/src/stacks/backend-stack.ts
@@ -106,7 +106,6 @@ export class BackendStack extends cdk.Stack {
       stringValue: api.url,
     })
 
-    //b.s. example of API paths
     const v1 = api.root.addResource("v1")
     const playerHand = v1.addResource("playerHand")
 
@@ -161,6 +160,9 @@ export class BackendStack extends cdk.Stack {
         "application/json": playerHandModel,
       },
       requestValidator: playerHandPutValidator,
+    })
+    const playerHandOption = playerHand.addMethod("OPTIONS", apiIntegration, {
+      apiKeyRequired: false,
     })
 
     const plan = api.addUsagePlan("legalBrawlUsagePlan", {


### PR DESCRIPTION
# Purpose :dart:

An `OPTIONS` method has been added to the API, and each response from the API includes the mandatory headers to satisfy CORS requirements.

Without these changes, Cross-Origin-Requests against the API will fail. The Infrastructure is set up so that the Lambda acts as the proxy for handling requests. Because of this, the Lambda is responsible for returning the headers for requests coming in.

# Context :brain:

It was discovered that while running the game on `itch.io`, the platform was performing CORS requests. Returning the following error:

_Access to fetch at **API-URL** has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled._

# Notes :notebook:

Alternatively, API Gateway can reply with CORS headers itself, though it would need to be configured to also pass through the Lambda response. This implementation proved easier to exercise
