### PR TITLE
ci: Adds ci for infra stack

### DIFF
--- a/.github/workflows/legalbrawl-backend-ops-lint.yaml
+++ b/.github/workflows/legalbrawl-backend-ops-lint.yaml
@@ -1,0 +1,32 @@
+name: Legal Brawl Backend Infra Linting & Testing
+on:
+  push:
+    paths:
+      - "backend/ops/**"
+      - ".github/workflows/legalbrawl-backend-ops-lint.yaml"
+
+jobs:
+  cdk-test:
+    strategy:
+      fail-fast: true
+      matrix:
+        task: [prettier, eslint, tsc, test]
+    defaults:
+      run:
+        working-directory: ./backend/ops/
+    name: legalbrawl-cdk-stack-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - uses: bahmutov/npm-install@v1
+        with:
+          working-directory: "backend/ops/"
+          useLockFile: false
+
+      - run: |
+          yarn run ${{ matrix.task }}


### PR DESCRIPTION
# Purpose :dart:

These changes add ci to the `legalBrawl` infra code.

In PRs, contributors will be able to see if their incoming changes following their pushses will pass the bare minimum testing and Linting requirments set by `eslint` and the `jest` tests.

The use of linting and testing will foster greater confidence of incoming changes when a merge is proposed.

# Context :brain:

Part of an effort to support the ongoing health of `LegaBraw`l ❤️l
