### PR TITLE
fix: Adds card length validation in parseBody

### DIFF
--- a/backend/src/aws/apigateway.go
+++ b/backend/src/aws/apigateway.go
@@ -371,9 +371,22 @@ func validateBody(b body) error {
 		return fmt.Errorf("playerId %v is not a valid UUID format: %w", b.HandInfo.PlayerId, err)
 	}
 
+	err = validateCards(b.HandInfo.Cards)
+	if err != nil {
+		return fmt.Errorf("submitted cards did not pass validation: %w", err)
+	}
+
 	err = validateSubmittedVersion(b.HandInfo.Version, env.PlayerHandVersion)
 	if err != nil {
 		return fmt.Errorf("submitted version did not pass validation: %w", err)
+	}
+
+	return nil
+}
+
+func validateCards(c []int16) error {
+	if len(c) != 7 {
+		return fmt.Errorf("card count %v is not equal to 7. Submitted Cards:%v", len(c), c)
 	}
 
 	return nil


### PR DESCRIPTION
# Purpose :dart:

This change introduces card-length validation when `playerHands` are submitted via POST or PUT methods. This is so that players cannot submit card configurations that are not 7 cards in quantity.

# Context :brain:

It was discovered that there was no internal validation for submitted cards. Crafty players could tamper requests and set card configurations that are greater than, or less than the hand limit set by the client application.
