### PR TITLE
fix: Golang CI file open errors

### DIFF
--- a/.github/workflows/legalbrawl-backend-src-lint.yaml
+++ b/.github/workflows/legalbrawl-backend-src-lint.yaml
@@ -42,6 +42,8 @@ jobs:
         with:
           working-directory: ${{env.WORK_DIR}}
           args: "--timeout=5m"
+          skip-pkg-cache: true
+          skip-build-cache: true
 
   go-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Purpose :dart:

This commit fixes an issue where `golangci-lint` throws a series of errors claiming to unable to open untarred files. This is supposedly because the tool is supposed to run in isolation in Github actions. Read:with no other accompanying steps, or cache (what?).

# Context :brain:

In previous Github Actions runs using `golangci-lint`, a series of errors were being thrown and it was annoying to look at.

# Notes :notebook: <!-- Optional --->

Refer to: https://github.com/golangci/golangci-lint-action/issues/244
