### PR TITLE
chore: game-off-2022 configuration tweaks

### DIFF
--- a/backend/ops/__tests__/__snapshots__/backend.test.ts.snap
+++ b/backend/ops/__tests__/__snapshots__/backend.test.ts.snap
@@ -873,7 +873,7 @@ exports[`legalBrawlBackendStack it synths and snapshots 1`] = `
           },
         ],
         "PointInTimeRecoverySpecification": {
-          "PointInTimeRecoveryEnabled": false,
+          "PointInTimeRecoveryEnabled": true,
         },
         "ProvisionedThroughput": {
           "ReadCapacityUnits": 5,
@@ -883,6 +883,102 @@ exports[`legalBrawlBackendStack it synths and snapshots 1`] = `
       },
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Delete",
+    },
+    "playerHandsTableReadScalingTarget3AFD5EE0": {
+      "Properties": {
+        "MaxCapacity": 20,
+        "MinCapacity": 5,
+        "ResourceId": {
+          "Fn::Join": [
+            "",
+            [
+              "table/",
+              {
+                "Ref": "playerHandsTable470492D8",
+              },
+            ],
+          ],
+        },
+        "RoleARN": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":iam::12345678901234:role/aws-service-role/dynamodb.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_DynamoDBTable",
+            ],
+          ],
+        },
+        "ScalableDimension": "dynamodb:table:ReadCapacityUnits",
+        "ServiceNamespace": "dynamodb",
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+    },
+    "playerHandsTableReadScalingTargetTracking4B0D5B8F": {
+      "Properties": {
+        "PolicyName": "legalBrawlBackendStackplayerHandsTableReadScalingTargetTracking52D5952C",
+        "PolicyType": "TargetTrackingScaling",
+        "ScalingTargetId": {
+          "Ref": "playerHandsTableReadScalingTarget3AFD5EE0",
+        },
+        "TargetTrackingScalingPolicyConfiguration": {
+          "PredefinedMetricSpecification": {
+            "PredefinedMetricType": "DynamoDBReadCapacityUtilization",
+          },
+          "TargetValue": 50,
+        },
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+    },
+    "playerHandsTableWriteScalingTarget21D3890C": {
+      "Properties": {
+        "MaxCapacity": 20,
+        "MinCapacity": 5,
+        "ResourceId": {
+          "Fn::Join": [
+            "",
+            [
+              "table/",
+              {
+                "Ref": "playerHandsTable470492D8",
+              },
+            ],
+          ],
+        },
+        "RoleARN": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":iam::12345678901234:role/aws-service-role/dynamodb.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_DynamoDBTable",
+            ],
+          ],
+        },
+        "ScalableDimension": "dynamodb:table:WriteCapacityUnits",
+        "ServiceNamespace": "dynamodb",
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+    },
+    "playerHandsTableWriteScalingTargetTrackingF7FD4BF1": {
+      "Properties": {
+        "PolicyName": "legalBrawlBackendStackplayerHandsTableWriteScalingTargetTracking16F69568",
+        "PolicyType": "TargetTrackingScaling",
+        "ScalingTargetId": {
+          "Ref": "playerHandsTableWriteScalingTarget21D3890C",
+        },
+        "TargetTrackingScalingPolicyConfiguration": {
+          "PredefinedMetricSpecification": {
+            "PredefinedMetricType": "DynamoDBWriteCapacityUtilization",
+          },
+          "TargetValue": 50,
+        },
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
     },
   },
   "Rules": {

--- a/backend/ops/src/stacks/backend-stack.ts
+++ b/backend/ops/src/stacks/backend-stack.ts
@@ -16,7 +16,7 @@ export class BackendStack extends cdk.Stack {
       partitionKey: { name: "version", type: dynamodb.AttributeType.STRING },
       sortKey: { name: "playerId", type: dynamodb.AttributeType.STRING },
       billingMode: dynamodb.BillingMode.PROVISIONED,
-      pointInTimeRecovery: false,
+      pointInTimeRecovery: true,
       removalPolicy: cdk.RemovalPolicy.DESTROY, //Swap this to `retain` when we got something that is shaping up nicely
       tableName: "playerHands",
     })

--- a/backend/ops/src/stacks/backend-stack.ts
+++ b/backend/ops/src/stacks/backend-stack.ts
@@ -21,6 +21,22 @@ export class BackendStack extends cdk.Stack {
       tableName: "playerHands",
     })
 
+    const readScaling = playerHandsTable.autoScaleReadCapacity({
+      minCapacity: 5,
+      maxCapacity: 20,
+    })
+    readScaling.scaleOnUtilization({
+      targetUtilizationPercent: 50,
+    })
+
+    const writeScaling = playerHandsTable.autoScaleWriteCapacity({
+      minCapacity: 5,
+      maxCapacity: 20,
+    })
+    writeScaling.scaleOnUtilization({
+      targetUtilizationPercent: 50,
+    })
+
     //The Lambda to handle requests coming through the API Gateway
     //Lambda would be written in golang
     const lambdaFn = new lambda.Function(this, "legalBrawlApiHandler", {


### PR DESCRIPTION
# Purpose :dart:

This changes enables autoscaling, and PITR (point-in-time-recovery) for the `playerHands` table.

This change isn't based off any calculations of traffic in mind, though there isn't any intention to set up on-demand scaling at the risk of paying for an insane bill. The goal for setting up autoscaling for the table is to allow more gamejammers to try out our game.

PITR has been enabled as a tool in case the database needs to be rolled back during the game jam.

# Context :brain:

`game-off-2022` is afoot, and there's a possibility that we may get a spike in user traffic. 
